### PR TITLE
Use separate file pipes for jobs using the same source

### DIFF
--- a/job/executor.go
+++ b/job/executor.go
@@ -93,7 +93,7 @@ func (e *jobStepExecutor) createContainer(j *Job) (string, error) {
 
 	if step.usesFilePipe() {
 		opts.HostConfig = &docker.HostConfig{
-			Binds: []string{fmt.Sprintf("%s:%s", step.filePipePath(), step.Output)},
+			Binds: []string{fmt.Sprintf("%s:%s", j.currentStepFilePipePath(), step.Output)},
 		}
 	}
 

--- a/job/manager.go
+++ b/job/manager.go
@@ -109,13 +109,13 @@ func (jm *jobManager) executeStep(job *Job, stdIn io.Reader) (io.Reader, error) 
 	stdErrReader, stdErrWriter := io.Pipe()
 
 	if step.usesFilePipe() {
-		f, err := os.Create(step.filePipePath())
+		f, err := os.Create(job.currentStepFilePipePath())
 		if err != nil {
 			return nil, err
 		}
 
 		f.Close()
-		defer os.Remove(step.filePipePath())
+		defer os.Remove(job.currentStepFilePipePath())
 	} else {
 		buffer := &bytes.Buffer{}
 		stepOutput = buffer
@@ -153,7 +153,7 @@ func (jm *jobManager) executeStep(job *Job, stdIn io.Reader) (io.Reader, error) 
 
 	if step.usesFilePipe() {
 		// Grab data written to pipe file
-		b, err := ioutil.ReadFile(step.filePipePath())
+		b, err := ioutil.ReadFile(job.currentStepFilePipePath())
 		if err != nil {
 			return nil, err
 		}

--- a/job/types.go
+++ b/job/types.go
@@ -1,7 +1,6 @@
 package job // import "github.com/CenturyLinkLabs/dray/job"
 
 import (
-	"crypto/md5"
 	"fmt"
 	"io"
 	"strconv"
@@ -80,6 +79,12 @@ func (j Job) currentStepEnvironment() Environment {
 	return append(defaultEnvironment, j.currentStep().Environment...)
 }
 
+// CurrentStepFilePipePath returns file pipe path for the current step based on
+// job's ID and step's index
+func (j Job) currentStepFilePipePath() string {
+	return fmt.Sprintf("/tmp/%s-%d", j.ID, j.StepsCompleted)
+}
+
 // JobStep represents one of the individual steps in a Dray Job. A job step is
 // the name of the Docker image that should be executed along with some
 // metadata used to control the execution of that image.
@@ -105,10 +110,6 @@ func (js JobStep) usesStdErrPipe() bool {
 
 func (js JobStep) usesFilePipe() bool {
 	return strings.HasPrefix(js.Output, "/")
-}
-
-func (js JobStep) filePipePath() string {
-	return fmt.Sprintf("/tmp/%x", md5.Sum([]byte(js.Source)))
 }
 
 func (js JobStep) usesDelimitedOutput() bool {

--- a/job/types_test.go
+++ b/job/types_test.go
@@ -41,6 +41,19 @@ func TestJobCurrentStepEnvironment(t *testing.T) {
 	assert.Contains(t, env, var6)
 }
 
+func TestJobCurrentStepFilePipePath(t *testing.T) {
+	job := Job{
+		ID:           "foo",
+		StepsCompleted: 0,
+	}
+
+	assert.Equal(t, "/tmp/foo-0", job.currentStepFilePipePath())
+
+	job.StepsCompleted = 1
+	// Test if next step has different file pipe
+	assert.Equal(t, "/tmp/foo-1", job.currentStepFilePipePath())
+}
+
 func TestJobStepUsesStdOutPipe(t *testing.T) {
 	js := JobStep{}
 	assert.True(t, js.usesStdOutPipe())
@@ -72,13 +85,6 @@ func TestJobStepUsesFilePipe(t *testing.T) {
 
 	js = JobStep{Output: "foo"}
 	assert.False(t, js.usesFilePipe())
-}
-
-func TestJobStepFilePipePath(t *testing.T) {
-	js := JobStep{Source: "foo"}
-
-	// Using hard-coded md5 hash of the string "foo"
-	assert.Equal(t, "/tmp/acbd18db4cc2f85cedef654fccc4a4d8", js.filePipePath())
 }
 
 func TestEnvVarString(t *testing.T) {


### PR DESCRIPTION
Current behaviour uses job step's `Source` property to name the file pipe. But when multiple jobs using the same sources are started, they all try to access the same pipe causing them to fail.
This PR uses job's ID and index of step to create more unique pipe file.
