### PR TITLE
Remove job volumes after finishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 
 
+0.14.1 - 2016-10-03
+-------------------
+### Fixed
+- Remove job volumes after finishing
+
 0.14.0 - 2016-09-21
 -------------------
 ### Added

--- a/job/executor.go
+++ b/job/executor.go
@@ -65,6 +65,7 @@ func (e *jobStepExecutor) Inspect(j *Job) error {
 func (e *jobStepExecutor) CleanUp(j *Job) error {
 	removeOpts := docker.RemoveContainerOptions{
 		ID: j.currentStep().id,
+		RemoveVolumes: true,
 	}
 
 	err := e.client.RemoveContainer(removeOpts)


### PR DESCRIPTION
This PR fixes issue with filling up disk space by having dangling volumes after each step finishes.
